### PR TITLE
Bug Fix: Missing Values in Edit Profile Form Validation

### DIFF
--- a/renderer/pages/[locale]/profile/edit.tsx
+++ b/renderer/pages/[locale]/profile/edit.tsx
@@ -48,6 +48,22 @@ const EditProfilePage: NextPage = () => {
   >(defaultProfile?.color);
 
   const form = useForm<Profile>({
+    /*
+     * Providing initial values prevents runtime errors by ensuring the validate
+     * function has data to work with, even before user input.
+     */
+    initialValues: {
+      bio: "",
+      color: "red",
+      createdAt: 0,
+      name: {
+        firstName: "",
+        lastName: "",
+      },
+      username: "",
+      updatedAt: 0,
+      uuid: "",
+    },
     validate: {
       // Error messages are currently not used. The form only proceeds if all fields are valid.
       name: {


### PR DESCRIPTION
This PR fixes a bug that occurred when navigating to the "Edit Profile" route. The form validation logic expected values to be provided, but none were available, causing an error. The issue has been resolved by ensuring initial values are set for the form.