### PR TITLE
Add function to calculate the first nine average

### DIFF
--- a/renderer/lib/playing/stats/getFirstNineAverage.ts
+++ b/renderer/lib/playing/stats/getFirstNineAverage.ts
@@ -1,0 +1,27 @@
+import type { MatchRound } from "types/match";
+import { THROWS_PER_ROUND } from "utils/constants";
+
+/**
+ * Calculates the average score of the first nine throws based on the player's rounds.
+ *
+ * @param {MatchRound[]} playerRounds - An array of match rounds containing round data.
+ * @returns {number} The average score of the first nine throws, or 0 if no rounds are available.
+ *
+ */
+const getFirstNineAverage = (playerRounds: MatchRound[]): number => {
+  if (playerRounds.length === 0) return 0;
+
+  const MaxRounds = Math.floor(9 / THROWS_PER_ROUND);
+
+  // Take the rounds needed for nine darts  and calculate the average of the scores
+  const firstThreeRounds = playerRounds.slice(0, MaxRounds);
+
+  const totalScore = firstThreeRounds.reduce(
+    (sum, round) => sum + round.roundTotal,
+    0
+  );
+
+  return totalScore / firstThreeRounds.length;
+};
+
+export default getFirstNineAverage;

--- a/renderer/pages/[locale]/match/playing.tsx
+++ b/renderer/pages/[locale]/match/playing.tsx
@@ -60,6 +60,7 @@ import { useRouter } from "next/router";
 import { useElapsedTime } from "use-elapsed-time";
 import { modals } from "@mantine/modals";
 import addMatchToDatabase from "@/lib/db/matches/addMatch";
+import getFirstNineAverage from "@/lib/playing/stats/getFirstNineAverage";
 
 const PlayingPage: NextPage = () => {
   const theme = useMantineTheme();
@@ -427,10 +428,13 @@ const PlayingPage: NextPage = () => {
                         opacity={0.7}
                         justify="space-between"
                       >
-                        {/* TODO: Calc first nine average... */}
                         <span>
-                          {t("stats.firstNineAvg")}
-                          {""}: 0
+                          {t("stats.firstNineAvg")}:{" "}
+                          <NumberFormatter
+                            decimalScale={2}
+                            defaultValue={0}
+                            value={getFirstNineAverage(players[_idx].rounds)}
+                          />
                         </span>
                         <span>
                           {t("stats.highestScore")}:{" "}


### PR DESCRIPTION
This PR introduces a new function, `getFirstNineAverage`, to calculate the average score of the first nine throws based on a player's match rounds.