### PR TITLE
Fix incorrect match outcomes for Single-Out mode when finishing with double-out

### DIFF
--- a/renderer/pages/[locale]/match/playing.tsx
+++ b/renderer/pages/[locale]/match/playing.tsx
@@ -178,6 +178,10 @@ const PlayingPage: NextPage = () => {
       return false;
     }
 
+    if (checkout === "Single") {
+      return !lastThrow.isDouble && !lastThrow.isTriple;
+    }
+
     if (checkout === "Double") {
       return lastThrow.isDouble || lastThrow.isBullseye;
     }


### PR DESCRIPTION
Selecting `Single-Out` in the lobby could result in the match finishing incorrectly with a winner after throwing a double out